### PR TITLE
Optimise FTP download performance.

### DIFF
--- a/src/util/updater.ts
+++ b/src/util/updater.ts
@@ -181,7 +181,7 @@ const updaterGetCRCInfo$ = (logConfig: LogConfig = defaultLogConfig) =>
  * @param client
  * @param logConfig
  */
- const updaterGetRemoteFile$ = (
+const updaterGetRemoteFile$ = (
   fileInfo: RemoteFileInfo,
   client: FTP,
   logConfig: LogConfig = defaultLogConfig

--- a/src/util/updater.ts
+++ b/src/util/updater.ts
@@ -181,7 +181,7 @@ const updaterGetCRCInfo$ = (logConfig: LogConfig = defaultLogConfig) =>
  * @param client
  * @param logConfig
  */
-const updaterGetRemoteFile$ = (
+ const updaterGetRemoteFile$ = (
   fileInfo: RemoteFileInfo,
   client: FTP,
   logConfig: LogConfig = defaultLogConfig
@@ -203,12 +203,19 @@ const updaterGetRemoteFile$ = (
           logConfig.channels
         );
         MainLogDownloadFilePercentageStatusSubject.next(0);
-        let buffer = Buffer.from('');
+        let bufferPercent = 0;
+        let bufferLength  = 0;
+        const buffer: Buffer[] = [];
         socket.on('data', (d) => {
-          buffer = Buffer.concat([buffer, d]);
-          MainLogDownloadFilePercentageStatusSubject.next(
-            Math.floor((buffer.byteLength / fileInfo.size) * 100)
-          );
+          buffer.push(d);
+          
+          bufferLength += d.byteLength
+          let newBufferPercent = Math.floor((bufferLength / fileInfo.size) * 100);
+          if(newBufferPercent !== bufferPercent)
+          {
+            bufferPercent = newBufferPercent;
+            MainLogDownloadFilePercentageStatusSubject.next(bufferPercent);
+          }
         });
 
         socket.on('close', (errClose) => {
@@ -220,7 +227,7 @@ const updaterGetRemoteFile$ = (
             );
             throw errClose;
           }
-          res(buffer);
+          res(Buffer.concat(buffer));
         });
         socket.resume();
       });


### PR DESCRIPTION
 * Reworked method of buffering file downloads to significantly improve performance.
 * Only call MainLogDownloadFilePercentageStatusSubject.next() when the percentage actually changes to cut down amount of unnecessary function calls.


Previously the implementation was calling Buffer.concat to create a new buffer, with data copied from old buffer every time the socket emitted a data event. This is fairly heavy on the CPU, especially with the larger files. We are now appending these buffers to an array, and making a single concat call when the file has finished downloading.

The MainLogDownloadFilePercentageStatusSubject.next() method which is used to update the progress bar while downloading files was being called every event as well, even if the number was the same.

Prior to the changes you could see large amounts of time spent on these methods and high CPU usage while performing the initial download.
<img width="1648" alt="prechange" src="https://user-images.githubusercontent.com/92635906/137591474-2efc9aab-bf33-4464-9467-4c8f91402867.png">

Post changes:
<img width="1648" alt="postchanges" src="https://user-images.githubusercontent.com/92635906/137591500-4ca3c4a0-9d28-4c88-bff8-babb5237560e.png">

When pointing the tests at a local FTP mirror I would find the larger files sit around 1.3MB/s on my desktop with an SSD and a 6700k. After the changes I was able to download from my local server at 150MB/s.
